### PR TITLE
Adding tests for graphDB

### DIFF
--- a/data-config.ttl
+++ b/data-config.ttl
@@ -1,0 +1,49 @@
+#
+# RDF4J configuration template for a GraphDB repository
+#
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
+@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix graphdb: <http://www.ontotext.com/config/graphdb#>.
+
+[] a rep:Repository ;
+    rep:repositoryID "testplace" ;
+    rdfs:label "" ;
+    rep:repositoryImpl [
+        rep:repositoryType "graphdb:SailRepository" ;
+        sr:sailImpl [
+            sail:sailType "graphdb:Sail" ;
+
+            graphdb:read-only "false" ;
+
+            # Inference and Validation
+            graphdb:ruleset "rdfsplus-optimized" ;
+            graphdb:disable-sameAs "true" ;
+            graphdb:check-for-inconsistencies "false" ;
+
+            # Indexing
+            graphdb:entity-id-size "32" ;
+            graphdb:enable-context-index "false" ;
+            graphdb:enablePredicateList "true" ;
+            graphdb:enable-fts-index "false" ;
+            graphdb:fts-indexes ("default" "iri") ;
+            graphdb:fts-string-literals-index "default" ;
+            graphdb:fts-iris-index "none" ;
+
+            # Queries and Updates
+            graphdb:query-timeout "0" ;
+            graphdb:throw-QueryEvaluationException-on-timeout "false" ;
+            graphdb:query-limit-results "0" ;
+
+            # Settable in the file but otherwise hidden in the UI and in the RDF4J console
+            graphdb:base-URL "http://example.org/owlim#" ;
+            graphdb:defaultNS "" ;
+            graphdb:imports "" ;
+            graphdb:repository-type "file-repository" ;
+            graphdb:storage-folder "storage" ;
+            graphdb:entity-index-size "10000000" ;
+            graphdb:in-memory-literal-properties "true" ;
+            graphdb:enable-literal-index "true" ;
+        ]
+    ].

--- a/run_tests_under_graphdb
+++ b/run_tests_under_graphdb
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+if [ $# -lt 1 ]; then
+    echo "ERROR: provide tests to run under the graphDB server"
+    exit 1
+fi
+
+### To use graphDB for running queries and saving to CSV file
+
+# 1. start graphDB and configure it to be stopped when we exit from the script
+
+docker run --name graphdb --rm -d -p 8889:7200 ontotext/graphdb:10.3.1
+export GRAPHDB_DB_NAME=testplace
+export GRAPHDB_URL=http://localhost:8889/
+export GRAPHDB_QUERY_URL="${GRAPHDB_URL}/repositories/${GRAPHDB_DB_NAME}"
+export GRAPHDB_API_URL="${GRAPHDB_QUERY_URL}/statements"
+
+trap "docker stop graphdb" SIGINT SIGHUP SIGABRT EXIT
+
+echo "Waiting for graphDB to start"
+while ! curl --silent "$GRAPHDB_URL/rest/repositories" | grep '\[\]'; do
+    :
+done
+
+sleep 2;  # sleep a little more for server to come up, no other means so far were sufficient
+
+echo "GraphDB now needs to be set up"
+
+echo "Making a new database called testplace at $GRAPHDB_URL/repositories/testplace"
+curl -X PUT $GRAPHDB_URL/repositories/testplace --data-binary "@data-config.ttl" -H "Content-Type: application/x-turtle"
+
+while ! curl --silent "$GRAPHDB_URL/rest/repositories" | grep 'testplace'; do
+    :
+done
+
+echo "I am happily done and content with the world"
+
+for f in "$@"; do
+    echo "Running test $f"
+    time "$f"
+done

--- a/test_1.sh
+++ b/test_1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -eu
-# set -o pipefail
+set -o pipefail
 
 
 # 2. to upload all the turtle files, from the root of this repo do:


### PR DESCRIPTION
- run_tests_under_graphdb -> make tests run with https://graphdb.ontotext.com/ (see also https://neurobagel.org/infrastructure/#setup-for-the-first-run for some general commands)
- data-config.ttl -> required file to create a first database in graphDB (so you can upload data). **note**: the `repositoryID` field must match the `$GRAPHDB_DB_NAME` in the script.

When graphDB starts, you first must make a new database (using the special ttl file):
![image](https://github.com/yarikoptic/simple2_NIDM_examples/assets/1302022/90cc4cfb-b797-46ff-992d-fb606192d21e)

